### PR TITLE
Raspberry Pi Dots board isn't a HAT

### DIFF
--- a/src/en/overlay/dots.md
+++ b/src/en/overlay/dots.md
@@ -92,7 +92,7 @@ pin:
 -->
 #Raspberry Pi Dots
 
-###Dots is a Dot to Dot HAT board for the Raspberry Pi that lets you join-the-dots with BARE Conductive Paint!
+###Dots is a Dot to Dot board for the Raspberry Pi that lets you join-the-dots with BARE Conductive Paint!
 
 Every Dot on the Dots board is a "floating" metal contact just waiting to be pulled down to ground with a dab of paint.
 


### PR DESCRIPTION
...as it doesn't have an EEPROM chip. https://www.raspberrypi.org/blog/dots-board-giveaway/