### PR TITLE
Remove power pins

### DIFF
--- a/src/de/overlay/iqaudio-pi-dac.md
+++ b/src/de/overlay/iqaudio-pi-dac.md
@@ -24,7 +24,6 @@ pin:
   18:
     name: Rotary Encoder
     description: (optional) 
-  20:
   22:
     name: IR Sensor
     description: (optional) 

--- a/src/de/overlay/piglow.md
+++ b/src/de/overlay/piglow.md
@@ -8,13 +8,9 @@ buy: http://shop.pimoroni.com/products/piglow
 description: 18 einfache LEDs als Spirale angeordnet und über Python ansteuerbar.
 pincount: 26
 pin:
-  '1': {}
-  '2': {}
   '3':
     mode: i2c
   '5':
     mode: i2c
-  '14': {}
-  '17': {}
 -->
 #PiGlow

--- a/src/es/overlay/iqaudio-pi-dac.md
+++ b/src/es/overlay/iqaudio-pi-dac.md
@@ -24,7 +24,6 @@ pin:
   '18':
     name: Codificador rotatorio
     description: (opcional) 
-  '20':
   '22':
     name: Sensor de infrarrojos
     description: (opcional) 


### PR DESCRIPTION
Allows `de` and `es` to be made again, now that #64 has been merged.
Apologies for not doing sufficient testing the first time before submitting the PR!