### PR TITLE
Add Cirrus Logic Audio Card

### DIFF
--- a/src/en/overlay/cirruslogicaudiocard.md
+++ b/src/en/overlay/cirruslogicaudiocard.md
@@ -1,0 +1,78 @@
+<!--
+---
+name: Cirrus Logic Audio Card
+manufacturer: Cirrus Logic and element14
+url: http://www.element14.com/community/community/raspberry-pi/raspberry-pi-accessories/cirrus_logic_audio_card
+buy: http://www.element14.com/community/community/raspberry-pi/raspberry-pi-accessories/cirrus_logic_audio_card
+description: Cirrus Logic Audio Card offers an unprecedented level of features and performance for avid audiophiles who want to use their Raspberry Pi for audio applications.
+pincount: 40
+pin:
+  '3':
+    name: SDA1
+    mode: i2c
+    description: WM8804 I2C - SDA
+  '5':
+    name: SCL1
+    mode: i2c
+    description: WM8804 I2C - SCLK
+  '11':
+    name: GPIO_GEN0
+    mode: input
+    description: WM5102 RST
+  '12':
+    name: PCM_CLK
+    mode: input
+    description: WM5102 AIF PCM - BCLK
+  '15':
+    name: GPIO_GEN3
+    mode: input
+    description: WM5102 LDO Enable
+  '16':
+    name: GPIO_GEN4
+    mode: input
+    description: WM8804 Control I/F Config
+  '19':
+    name: SPI_MOSI
+    mode: spi
+    description: WM5102 SPI - MOSI
+  '21':
+    name: SPI_MISO
+    mode: spi
+    description: WM5102 SPI - MISO
+  '23':
+    name: SPI_SCLK
+    mode: spi
+    description: WM5102 SPI - SCLK1
+  '24':
+    name: SPI_CE0_N
+    mode: input
+    description: WM8804 RST
+  '26':
+    name: SPI_CE1_N
+    mode: input
+    description: WM5102 SPI - CE
+  '35':
+    name: PCM_FS
+    mode: input
+    description: WM5102 AIF PCM - FS
+  '38':
+    name: PCM_DIN
+    mode: input
+    description: WM5102 AIF PCM - DIN
+  '40':
+    name: PCM_DOUT
+    mode: input
+    description: WM5102 AIF PCM - DOUT
+-->
+#Cirrus Logic Audio Card
+
+###Cirrus Logic Audio Card offers an unprecedented level of features and performance for avid audiophiles who want to use their Raspberry Pi for audio applications.
+
+Features:
+  - For use with Raspberry Pi
+  - Capable of rendering HD Audio, at 24-bit, 192kHz
+  - 3.5mm 4-pole jack for a headset/boom mic combination for gaming or VoIP applications
+  - Two DMIC microphones onboard for stereo recording
+  - 3.5mm jack for Stereo Line Input for high quality audio recording or capture
+  - 3.5 mm jack Stereo Line Output for connection to devices such as external stereo amplifiers or powered speakers
+  - Stereo Digital input and output (SPDIF)

--- a/src/en/settings.yaml
+++ b/src/en/settings.yaml
@@ -45,3 +45,4 @@ overlays:
 - iqaudio-pi-dac
 - piano-hat
 - sense-hat
+- cirruslogicaudiocard

--- a/src/en/settings.yaml
+++ b/src/en/settings.yaml
@@ -45,4 +45,5 @@ overlays:
 - iqaudio-pi-dac
 - piano-hat
 - sense-hat
+- discohat
 - cirruslogicaudiocard

--- a/src/fr/template/layout.html
+++ b/src/fr/template/layout.html
@@ -31,7 +31,7 @@
 				<li><a href="https://github.com/Gadgetoid/Pinout2"><i class="fa fa-github"></i> Contribuez!</a></li>
 				{{lang_links}}
 			</ul>
-			<h1 class="logo"><a title="Raspberry Pi GPIO Pinout home" href="/pinout"><img src="{{resource_url}}pinout-logo.png" style="top:8px;" /><span>Raspberry Pi</span>n<span class="out">out</span></a></h1>
+			<h1 class="logo"><a title="Raspberry Pi GPIO Pinout home" href="/"><img src="{{resource_url}}pinout-logo.png" style="top:8px;" /><span>Raspberry Pi</span>n<span class="out">out</span></a></h1>
 			<div class="overlay-container">
 				<span>Tout savoir sur les cartes compatibles Raspberry Pi <i class="fa fa-arrow-right"></i></span>
 				<div class="drop-down">


### PR DESCRIPTION
I bought the card to test it with DiscoHAT. As I had to read through the manuals and check the used pins I thought of including my work to pinout.xyz. The card is really using every pin on the connector but many pins are marked as unused. Here I tried to declare only the pins that are actually used for something.

The reason why this card was interesting is that it had stereo microphones built-in on the board. It also has digital sound in/out which may be cool when performing for live audiences.

All the texts and data are taken from Cirrus Logic - elemnt14 manuals freely down loadable from the element14 web site.