### PR TITLE
made a start at #86

### DIFF
--- a/src/en/overlay/pi-digiamp+.md
+++ b/src/en/overlay/pi-digiamp+.md
@@ -1,0 +1,33 @@
+<!--
+---
+class: board
+type: multi
+name: "Pi-DigiAMP+"
+manufacturer: IQAudIO
+description: A combined DAC and 35w amplifier board.
+url: http://www.iqaudio.co.uk/home/9-pi-digiamp-0712411999650.html
+formfactor: 'HAT'
+pincount: 40
+eeprom: yes
+pin:
+  '15':
+    name: ID_SD
+-->
+#Pi-DigiAMP+
+
+The Pi-DigiAMP+ is an add-on board that includes a Digital to Analog Converter (DAC) and powerful 35w stereo amplifier. If you want to turn your Raspberry Pi into a working Hi Fi stereo, just add speakers and you're off.
+
+The Pi-DigiAMP+ exposes some of the Pi's pins via a header.
+
+Pin | Name | Name | Pin
+--- | --- | --- | ---
+1 | GPIO23 (Rotary encoder) | GPIO22 (Mute) | 2
+3 | GPIO24 (Rotary encoder) | GPIO25 (IR)   | 4
+5 | 5v                      | 3v3           | 6
+7 | I2C SCL1                | Ground (0v)   | 8
+9 | I2C SDA1                | Ground (0v)   | 10
+
+
+These can be used for whatever you like but some are used by some additional software the IQAudIO provide to easily support a rotary encoder for physically controlling volume, a hardware mute switch and IR control.
+
+The official documentation can be found on the [IQAudIO website](http://www.iqaudio.com/downloads/IQaudIO.pdf).

--- a/src/en/overlay/pi-digiamp+.md
+++ b/src/en/overlay/pi-digiamp+.md
@@ -10,10 +10,27 @@ formfactor: 'HAT'
 pincount: 40
 eeprom: yes
 pin:
+  '3':
+    name: I2C
+  '5':
+    name: I2C
   '15':
-    name: ID_SD
+    name: GEN3
+  '27':
+    name: ID_SD (HAT)
+  '35':
+    name: I2S
+  '12':
+    name: I2S (CLK)
+  '28':
+    name: HAT
+  '38':
+    name: I2S (DIN)
+  '40':
+    name: I2S
 -->
-#Pi-DigiAMP+
+
+# Pi-DigiAMP+
 
 The Pi-DigiAMP+ is an add-on board that includes a Digital to Analog Converter (DAC) and powerful 35w stereo amplifier. If you want to turn your Raspberry Pi into a working Hi Fi stereo, just add speakers and you're off.
 


### PR DESCRIPTION
I can't really figure out which pins are used and which are not based on the [docs](http://www.iqaudio.com/downloads/IQaudIO.pdf);

This PR is specifically for the Pi-DigiAMP+ but it's not clear to me from the pin diagram if the Pi-DAC+ or Pi-AMP+ share all the pins or not.

<img width="658" alt="screen shot 2016-02-09 at 21 37 40" src="https://cloud.githubusercontent.com/assets/49573/12931389/64124f22-cf75-11e5-82f6-b801ac570347.png">
